### PR TITLE
修复NavigationBarIcon在浅色模式下仍采用Brightness.light

### DIFF
--- a/lib/app_init.dart
+++ b/lib/app_init.dart
@@ -62,7 +62,7 @@ mixin AppInit<T extends StatefulWidget> on
       handler: (isNight) {
         setNavigationBarStyle(
           isNight ? nightPrimaryColor : Colors.white,
-          isNight ? Brightness.light : Brightness.light
+          isNight ? Brightness.light : Brightness.dark
         );
       }
     );
@@ -129,6 +129,10 @@ mixin AppInit<T extends StatefulWidget> on
       settingsProvider.theme = otherPref.lastTheme;
     }
 
-    setNavigationBarStyle(settingsProvider.theme == 'night' ? nightPrimaryColor : Colors.white);
+		if (settingsProvider.theme == 'night') {
+			setNavigationBarStyle(nightPrimaryColor, Brightness.light);
+		} else {
+			setNavigationBarStyle(Colors.white, Brightness.dark);
+		}
   }
 }

--- a/lib/utils/ui/set_status_bar.dart
+++ b/lib/utils/ui/set_status_bar.dart
@@ -20,7 +20,7 @@ void setStatusBarTextBrightness(Brightness brightness) {
   );
 }
 
-void setNavigationBarStyle(Color backgroundColor, [Brightness iconBrightness]) {
+void setNavigationBarStyle(Color backgroundColor, Brightness iconBrightness) {
   SystemChrome.setSystemUIOverlayStyle(
     SystemUiOverlayStyle(
       systemNavigationBarColor: backgroundColor,


### PR DESCRIPTION
详见#3